### PR TITLE
Drop ctrl+c as a quit key

### DIFF
--- a/src/braindrop/app/messages/commands.py
+++ b/src/braindrop/app/messages/commands.py
@@ -176,7 +176,7 @@ class ChangeTheme(Command):
 class Quit(Command):
     """Quit the application"""
 
-    BINDING_KEY = "f10, ctrl+c, ctrl+q"
+    BINDING_KEY = "f10, ctrl+q"
 
 
 ##############################################################################


### PR DESCRIPTION
Now that I've got Input and TextArea widgets kicking around it makes sense to learn into Textual's questionable decision to hijack ctrl+c.