### PR TITLE
Reduce the chance of errors related to non-urly URLs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Braindrop ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Fixed unnecessary error notifications when asking raindrop.io for
+  suggestions for an URL that isn't really an URL.
+- Suggested URL when making a new raindrop is now taken from the first line
+  of the clipboard, ignoring any other text.
+
 ## v0.1.0
 
 **Released: 2025-01-03**


### PR DESCRIPTION
Changes relating to handling URLs in the edit dialog:

- Only go looking for suggestions from raindrop.io if an URL actually looks like an URL.
- When looking for an URL suggestion for a new raindrop, only look at the first line of the clipboard, and be sure to strip it back.
