### PR TITLE
Improve how the age and the tags share their line

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
 **Released: WiP**
 
 - Small tweaks to the styling of the raindrop details panel.
+- Improved the way the age and the tags share the line in the raindrops view
+  widget.
 
 ## v0.1.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@
 
 - Small tweaks to the styling of the raindrop details panel.
 - Improved the way the age and the tags share the line in the raindrops view
-  widget.
+  widget. ([#31](https://github.com/davep/braindrop/pull/31))
 
 ## v0.1.1
 

--- a/src/braindrop/app/widgets/raindrops_view.py
+++ b/src/braindrop/app/widgets/raindrops_view.py
@@ -93,11 +93,11 @@ class RaindropView(Option):
             body.append(excerpt)
 
         details = Table.grid(expand=True)
-        details.add_column(ratio=1)
         details.add_column()
+        details.add_column(justify="right")
         details.add_row(
-            f"[dim][italic]{naturaltime(self._raindrop.created) if self._raindrop.created else 'Unknown'}[/][/]",
-            f" [dim bold italic]{', '.join(str(tag) for tag in sorted(self._raindrop.tags))}[/]",
+            f"[dim][italic]{naturaltime(self._raindrop.created) if self._raindrop.created else 'Unknown'}[/][/] ",
+            f"[dim bold italic]{', '.join(str(tag) for tag in sorted(self._raindrop.tags))}[/]",
         )
 
         return Group(title, *body, details, self.RULE)


### PR DESCRIPTION
Small change to how the age of a raindrop and its tags share their line in the raindrops view widget.