### PR TITLE
Display any local data before looking to redownload

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@
 - Improved the styling of the main panels.
   ([#34](https://github.com/davep/braindrop/pull/34))
 - Existing data is now shown a wee bit earlier on startup.
+  ([#37](https://github.com/davep/braindrop/pull/37))
 
 ## v0.1.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@
   widget. ([#31](https://github.com/davep/braindrop/pull/31))
 - Improved the styling of the main panels.
   ([#34](https://github.com/davep/braindrop/pull/34))
+- Existing data is now shown a wee bit earlier on startup.
 
 ## v0.1.1
 

--- a/src/braindrop/app/screens/main.py
+++ b/src/braindrop/app/screens/main.py
@@ -211,6 +211,9 @@ class Main(Screen[None]):
     async def maybe_redownload(self) -> None:
         """Redownload the Raindrop data if it looks like server data is newer."""
 
+        # Ensure that whatever we have at the moment is visible.
+        self.populate_display()
+
         # First off, get the user information. It's via this where we'll
         # figure out the last server activity and will then be able to
         # figure out if we're out of date down here.
@@ -256,8 +259,7 @@ class Main(Screen[None]):
             )
         else:
             # It doesn't look like we're in a situation where we need to
-            # download data from the server. Display the local copy.
-            self.populate_display()
+            # download data from the server.
             return
 
         # Having got to this point, it looks like we really do need to pull


### PR DESCRIPTION
This PR ensures that any local data is shown as soon as possible, *then* the call out to get the user information, to then check if we need to refresh, can happen.