### PR TITLE
Move the source of "this is local to the app" collection truth into `SpecialCollection`

### DIFF
--- a/.sandbox/ask_for_local_collection.py
+++ b/.sandbox/ask_for_local_collection.py
@@ -1,0 +1,29 @@
+"""Ensure asking for a 'local' collection is a failure."""
+
+from asyncio import run
+
+from rich.pretty import pprint as print
+
+from braindrop.app.data import token_file
+from braindrop.raindrop import API, SpecialCollection
+
+
+async def make_it_rain() -> None:
+    try:
+        print(
+            await API(token_file().read_text().strip()).raindrops(
+                SpecialCollection.TRASH
+            )
+        )
+        print(
+            await API(token_file().read_text().strip()).raindrops(
+                SpecialCollection.BROKEN
+            )
+        )
+    except API.Error as error:
+        print(error)
+
+
+run(make_it_rain())
+
+### create_new_raindrop.py ends here

--- a/src/braindrop/raindrop/api.py
+++ b/src/braindrop/raindrop/api.py
@@ -263,10 +263,8 @@ class API:
             - `SpecialCollection.UNSORTED` - All `Raindrop`s not in a `Collection`.
             - `SpecialCollection.TRASH` - All trashed `Raindrop`s.
         """
-        assert collection not in (
-            SpecialCollection.UNTAGGED,
-            SpecialCollection.BROKEN,
-        ), f"{collection} is not a valid collection ID"
+        if not self.maybe_on_the_server(collection):
+            raise self.Error(f"{collection} is not a valid collection ID")
         page = 0
         raindrops: list[Raindrop] = []
         if count_update is not None:

--- a/src/braindrop/raindrop/api.py
+++ b/src/braindrop/raindrop/api.py
@@ -220,6 +220,26 @@ class API:
         result, user = await self._result_of(self._get, "user", "user")
         return User.from_json(user) if result and user is not None else None
 
+    @staticmethod
+    def maybe_on_the_server(collection: int | SpecialCollection) -> bool:
+        """Check if the given collection is likely to be on the server.
+
+        Args:
+            collection: The collection to check.
+
+        Returns:
+            `True` if likely on the server, `False` if not.
+
+        Notes:
+            This method doesn't check that the collection *is* on the
+            server, it just helps check that it might be.
+        """
+        try:
+            collection = SpecialCollection(collection)
+        except ValueError:
+            return collection > 0
+        return not collection.is_local
+
     async def raindrops(
         self,
         collection: int = SpecialCollection.ALL,

--- a/src/braindrop/raindrop/collection.py
+++ b/src/braindrop/raindrop/collection.py
@@ -94,11 +94,20 @@ class SpecialCollection(IntEnum):
     """A collection that contains all broken raindrops.
 
     Note:
-        Unlike the other special collection IDs defined here, the broken
-        collection isn't one that is supported via the API; but it's
-        available here so that it can be treated as just another
+
+        Unlike the other special collection IDs defined here, the untagged
+        and broken collections aren't supported via the API; but are
+        available here so that they can be treated as just another
         collection, with special handling within the main application.
+
+        See the `is_local` property to test if a collection is local in this
+        way.
     """
+
+    @property
+    def is_local(self) -> bool:
+        """Is this a locally-defined collection?"""
+        return self in (self.UNTAGGED, self.BROKEN)
 
     def __call__(self) -> Collection:
         """Turn a collection ID into a `Collection` object."""

--- a/tests/unit/test_special_collections.py
+++ b/tests/unit/test_special_collections.py
@@ -1,0 +1,28 @@
+"""Test the special collection enum."""
+
+##############################################################################
+# Pytest imports.
+from pytest import mark
+
+##############################################################################
+# Local imports.
+from braindrop.raindrop import SpecialCollection
+
+
+##############################################################################
+@mark.parametrize(
+    "collection, is_local",
+    (
+        (SpecialCollection.ALL, False),
+        (SpecialCollection.UNSORTED, False),
+        (SpecialCollection.TRASH, False),
+        (SpecialCollection.UNTAGGED, True),
+        (SpecialCollection.BROKEN, True),
+    ),
+)
+def test_local_collections(collection: SpecialCollection, is_local: bool) -> None:
+    """Does each collection ID correctly report if it's local or not?"""
+    assert collection.is_local is is_local
+
+
+### test_special_collections.py ends here

--- a/tests/unit/test_special_collections.py
+++ b/tests/unit/test_special_collections.py
@@ -6,7 +6,7 @@ from pytest import mark
 
 ##############################################################################
 # Local imports.
-from braindrop.raindrop import SpecialCollection
+from braindrop.raindrop import API, SpecialCollection
 
 
 ##############################################################################
@@ -23,6 +23,29 @@ from braindrop.raindrop import SpecialCollection
 def test_local_collections(collection: SpecialCollection, is_local: bool) -> None:
     """Does each collection ID correctly report if it's local or not?"""
     assert collection.is_local is is_local
+
+
+##############################################################################
+@mark.parametrize(
+    "collection, maybe_available",
+    (
+        (0, True),
+        (1, True),
+        (99, True),
+        (-1, True),
+        (-2, False),
+        (SpecialCollection.ALL, True),
+        (SpecialCollection.UNSORTED, True),
+        (SpecialCollection.TRASH, True),
+        (SpecialCollection.UNTAGGED, False),
+        (SpecialCollection.BROKEN, False),
+    ),
+)
+def test_maybe_on_the_server(
+    collection: int | SpecialCollection, maybe_available: bool
+) -> None:
+    """The API class should help us decide if we can ask for a collection."""
+    assert API.maybe_on_the_server(collection) is maybe_available
 
 
 ### test_special_collections.py ends here


### PR DESCRIPTION
Rather than decide out in the application code that a special collection is API-based or app-based, move that distinction into the API-level code.