### PR TITLE
Fix the doubled-up help text in the raindrops details panel

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Braindrop ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Fixed doubling-up of the raindrop details panel's help when the raindrop's
+  tags have focus. ([#39](https://github.com/davep/braindrop/issues/39))
+
 ## v0.2.0
 
 **Released: 2025-01-05**

--- a/src/braindrop/app/widgets/raindrop_details.py
+++ b/src/braindrop/app/widgets/raindrop_details.py
@@ -31,20 +31,10 @@ from ...raindrop import Raindrop, Tag
 from ..messages import ShowTagged
 from .extended_option_list import OptionListEx
 
-##############################################################################
-HELP = """
-## The highlighted Raindrop's details.
-
-This panel contains the details of the currently-highlighted Raindrop.
-"""
-"""The help to use in the widgets."""
-
 
 ##############################################################################
 class Tags(OptionListEx):
     """Show the tags for a Raindrop."""
-
-    HELP = HELP
 
     _ICON: Final[str] = Emoji.replace(":bookmark: ")
     """The icon to show before tags."""
@@ -178,7 +168,12 @@ class RaindropDetails(VerticalScroll):
     }
     """
 
-    HELP = HELP
+    HELP = """
+    ## The highlighted Raindrop's details
+
+    This panel contains the details of the currently-highlighted Raindrop.
+    """
+    """The help to use in the widgets."""
 
     BINDINGS = [
         Binding(

--- a/src/braindrop/app/widgets/raindrop_details.py
+++ b/src/braindrop/app/widgets/raindrop_details.py
@@ -173,7 +173,6 @@ class RaindropDetails(VerticalScroll):
 
     This panel contains the details of the currently-highlighted Raindrop.
     """
-    """The help to use in the widgets."""
 
     BINDINGS = [
         Binding(


### PR DESCRIPTION
The help was doubled up in the tags widget as well as in the panel itself; this had originally been done to make things work fine with Textual's own help panel. However, when I realised it wasn't a good approach to showing help for keyboard users I switched to my own help dialog, but forgot to undo this workaround.

Fixes #39