### PR TITLE
Remove unused imports

### DIFF
--- a/src/braindrop/app/widgets/raindrop_details.py
+++ b/src/braindrop/app/widgets/raindrop_details.py
@@ -4,7 +4,6 @@
 # Python imports.
 from datetime import datetime
 from typing import Any, Callable, Final
-from webbrowser import open as open_url
 
 ##############################################################################
 # Humanize imports.
@@ -20,7 +19,6 @@ from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalScroll
-from textual.message import Message
 from textual.reactive import var
 from textual.widgets import Label
 from textual.widgets.option_list import Option


### PR DESCRIPTION
Remove a couple more unused imports that are a hangover from #43.

As a side-note, I'm pretty sure `pylint` picks up this sort of issue, but it seems like `rye lint` doesn't. I wonder why that is and if there's any thought on adding that?