### PR TITLE
More raindrop details in list and detail panel

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@
 - Added <kbd>v</kbd> as a global key for visiting a currently-highlighted
   link. ([#43](https://github.com/davep/braindrop/pull/43))
 - Added public/private icons to the raindrops list.
+- Added public/private icons and the collection name to the raindrop detail
+  view.
 
 ## v0.2.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@
   ([#43](https://github.com/davep/braindrop/pull/43))
 - Added <kbd>v</kbd> as a global key for visiting a currently-highlighted
   link. ([#43](https://github.com/davep/braindrop/pull/43))
+- Added public/private icons to the raindrops list.
 
 ## v0.2.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,8 +11,9 @@
 - Added <kbd>v</kbd> as a global key for visiting a currently-highlighted
   link. ([#43](https://github.com/davep/braindrop/pull/43))
 - Added public/private icons to the raindrops list.
+  ([#48](https://github.com/davep/braindrop/pull/48))
 - Added public/private icons and the collection name to the raindrop detail
-  view.
+  view. ([#48](https://github.com/davep/braindrop/pull/48))
 
 ## v0.2.0
 

--- a/src/braindrop/app/data/local.py
+++ b/src/braindrop/app/data/local.py
@@ -384,11 +384,17 @@ class LocalData:
         Returns:
             The collection with that identity.
         """
+        if identity in SpecialCollection:
+            return SpecialCollection(identity)()
         return self._collections[identity]
 
     @property
     def collections(self) -> list[Collection]:
-        """A list of all known collections."""
+        """A list of all known collections.
+
+        Notes:
+            This is just the list of user-defined collections.
+        """
         return list(self._collections.values())
 
     def mark_downloaded(self) -> Self:

--- a/src/braindrop/app/data/local.py
+++ b/src/braindrop/app/data/local.py
@@ -384,9 +384,11 @@ class LocalData:
         Returns:
             The collection with that identity.
         """
-        if identity in SpecialCollection:
-            return SpecialCollection(identity)()
-        return self._collections[identity]
+        return (
+            SpecialCollection(identity)()
+            if identity in SpecialCollection
+            else self._collections[identity]
+        )
 
     @property
     def collections(self) -> list[Collection]:

--- a/src/braindrop/app/screens/help.py
+++ b/src/braindrop/app/screens/help.py
@@ -64,7 +64,7 @@ class HelpScreen(ModalScreen[None]):
     HelpScreen {
         align: center middle;
 
-        Vertical {
+        &> Vertical {
             width: 75%;
             height: 90%;
             background: $panel;

--- a/src/braindrop/app/screens/main.py
+++ b/src/braindrop/app/screens/main.py
@@ -304,6 +304,7 @@ class Main(Screen[None]):
         """Populate the display."""
         self.query_one(Navigation).data = self._data
         self.query_one(RaindropsView).data = self._data
+        self.query_one(RaindropDetails).data = self._data
         self.active_collection = self._data.all
         self.query_one(Navigation).highlight_collection(SpecialCollection.ALL())
 

--- a/src/braindrop/app/screens/main.py
+++ b/src/braindrop/app/screens/main.py
@@ -303,6 +303,7 @@ class Main(Screen[None]):
     def populate_display(self) -> None:
         """Populate the display."""
         self.query_one(Navigation).data = self._data
+        self.query_one(RaindropsView).data = self._data
         self.active_collection = self._data.all
         self.query_one(Navigation).highlight_collection(SpecialCollection.ALL())
 

--- a/src/braindrop/app/widgets/icons.py
+++ b/src/braindrop/app/widgets/icons.py
@@ -1,0 +1,26 @@
+"""Provides icons used within the widgets."""
+
+##############################################################################
+# Python imports.
+from typing import Final
+
+##############################################################################
+# Rich imports.
+from rich.emoji import Emoji
+
+##############################################################################
+# The various icons.
+
+BROKEN_ICON: Final[str] = Emoji.replace(":skull:")
+"""The icon for broken links."""
+
+UNSORTED_ICON: Final[str] = Emoji.replace(":thinking_face:")
+"""The icon for unsorted raindrops."""
+
+PUBLIC_ICON: Final[str] = Emoji.replace(":globe_with_meridians:")
+"""The icon to use for a public raindrop."""
+
+PRIVATE_ICON: Final[str] = Emoji.replace(":lock:")
+"""The icon to use for a private raindrop."""
+
+### icons.py ends here

--- a/src/braindrop/app/widgets/raindrops_view.py
+++ b/src/braindrop/app/widgets/raindrops_view.py
@@ -28,23 +28,12 @@ from ...raindrop import Raindrop
 from ..data import LocalData, Raindrops
 from ..messages import VisitLink
 from .extended_option_list import OptionListEx
+from .icons import BROKEN_ICON, PRIVATE_ICON, PUBLIC_ICON, UNSORTED_ICON
 
 
 ##############################################################################
 class RaindropView(Option):
     """An individual raindrop."""
-
-    BROKEN_ICON: Final[str] = Emoji.replace(":skull:")
-    """The icon for broken links."""
-
-    UNSORTED_ICON: Final[str] = Emoji.replace(":thinking_face:")
-    """The icon for unsorted raindrops."""
-
-    PUBLIC_ICON: Final[str] = Emoji.replace(":globe_with_meridians:")
-    """The icon to use for a public raindrop."""
-
-    PRIVATE_ICON: Final[str] = Emoji.replace(":lock:")
-    """The icon to use for a private raindrop."""
 
     RULE: Final[Rule] = Rule(style="dim")
     """The rule to place at the end of each view."""
@@ -93,9 +82,9 @@ class RaindropView(Option):
         title.add_column(justify="right")
         title.add_row(
             escape(self._raindrop.title),
-            f"{self.BROKEN_ICON if self._raindrop.broken else ''}"
-            f"{self.UNSORTED_ICON if self._raindrop.is_unsorted else ''}"
-            f"{self.PUBLIC_ICON if self._public else self.PRIVATE_ICON}",
+            f"{BROKEN_ICON if self._raindrop.broken else ''}"
+            f"{UNSORTED_ICON if self._raindrop.is_unsorted else ''}"
+            f"{PUBLIC_ICON if self._public else PRIVATE_ICON}",
         )
 
         body: list[Table] = []
@@ -137,10 +126,10 @@ class RaindropsView(OptionListEx):
     Each Raindrop may have one or more icons showing to the right, these
     include:
 
-    - {RaindropView.BROKEN_ICON} - The Raindrop has a broken link (*Raindrop Pro only*)
-    - {RaindropView.UNSORTED_ICON} - The Raindrop hasn't been sorted into a collection yet
-    - {RaindropView.PUBLIC_ICON} - The Raindrop is in a collection that is visible to the public
-    - {RaindropView.PRIVATE_ICON} - The Raindrop is in a collection that is private
+    - {BROKEN_ICON} - The Raindrop has a broken link (*Raindrop Pro only*)
+    - {UNSORTED_ICON} - The Raindrop hasn't been sorted into a collection yet
+    - {PUBLIC_ICON} - The Raindrop is in a collection that is visible to the public
+    - {PRIVATE_ICON} - The Raindrop is in a collection that is private
     """
 
     data: var[LocalData | None] = var(None, always_update=True)


### PR DESCRIPTION
This PR adds some more detail relating to a raindrop in the UI. This includes:

- A public/private icon for each raindrop in the main list panel.
- A public/private icon as well as the collection name in the raindrop details panel.

Incidental changes within this PR that relates to the main purpose:

- Fixed a small style leak within the help dialog, made obvious when using a list in the markdown help for the raindrops list view.
- Moved the icons into their own file as they're now shared between widgets.