### PR TITLE
Ensure locally-held collection of a trashed raindrop is the trash collection

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,9 @@
   ([#48](https://github.com/davep/braindrop/pull/48))
 - Added public/private icons and the collection name to the raindrop detail
   view. ([#48](https://github.com/davep/braindrop/pull/48))
+- Fixed a trashed raindrop, while still in trash, thinking its collection is
+  the last collection it was in.
+  ([#47](https://github.com/davep/braindrop/issues/47))
 
 ## v0.2.0
 

--- a/src/braindrop/app/data/local.py
+++ b/src/braindrop/app/data/local.py
@@ -548,7 +548,7 @@ class LocalData:
             As a side-effect the data is saved to storage.
         """
         if raindrop in self._all:
-            self._trash.push(raindrop.edit(collection=SpecialCollection.TRASH))
+            self._trash.push(raindrop.move_to(SpecialCollection.TRASH))
             self._all.remove(raindrop)
         else:
             self._trash.remove(raindrop)

--- a/src/braindrop/raindrop/raindrop.py
+++ b/src/braindrop/raindrop/raindrop.py
@@ -121,7 +121,12 @@ class Raindrop:
 
     @property
     def as_json(self) -> dict[str, Any]:
-        """The Raindrop as a JSON-friendly dictionary."""
+        """The Raindrop as a JSON-friendly dictionary.
+
+        Notes:
+            The data in here is a subset of all of the data and is only
+            intended for use with returning to the raindrop.io API.
+        """
         return {
             "collection": {"$id": self.collection},
             "cover": self.cover,

--- a/src/braindrop/raindrop/raindrop.py
+++ b/src/braindrop/raindrop/raindrop.py
@@ -161,6 +161,19 @@ class Raindrop:
         """
         return replace(self, **replacements)
 
+    def move_to(self, collection: int | SpecialCollection) -> Raindrop:
+        """Move the raindrop to a different collection.
+
+        Args:
+            The collection to move the raindrop into.
+
+        Returns:
+            A copy of the raindrop with its collection changed.
+        """
+        moved = self.edit(collection=int(collection))
+        moved.raw.get("collection", {})["$id"] = collection
+        return moved
+
     @property
     def is_brand_new(self) -> bool:
         """Is this a brand new Raindrop that hasn't been saved yet?"""

--- a/src/braindrop/raindrop/raindrop.py
+++ b/src/braindrop/raindrop/raindrop.py
@@ -152,6 +152,12 @@ class Raindrop:
 
         Returns:
             A copy of the raindrop with the edits made.
+
+        Notes:
+            This DOES NOT update the raw data, which should be considered
+            stale and unsafe to use. If you wish to use the `raw` property
+            after using this method you should update the server and pull
+            back a fresh copy of the raindrop.
         """
         return replace(self, **replacements)
 

--- a/tests/unit/test_raindrop.py
+++ b/tests/unit/test_raindrop.py
@@ -26,8 +26,23 @@ def test_editing_a_raindrop() -> None:
     """Test using the edit method to change a value in a Raindrop."""
     TITLE = "This is a test"
     raindrop = Raindrop(title=TITLE)
+    updated = raindrop.edit(title="Changed")
     assert raindrop.title == TITLE
-    assert raindrop.edit(title="Changed").title != TITLE
+    assert updated.title != TITLE
+
+
+##############################################################################
+def test_an_edited_raindrop_should_be_a_different_instance() -> None:
+    """When you edit a Raindrop it should result in a new instance."""
+    raindrop = Raindrop()
+    assert raindrop.edit(title="Changed") is not raindrop
+
+
+##############################################################################
+def test_editing_a_raindrop_property_that_does_not_exist() -> None:
+    """Attempting to edit a property that doesn't exist should be an error."""
+    with raises(TypeError):
+        Raindrop().edit(not_a_property=42)
 
 
 ##############################################################################
@@ -126,20 +141,6 @@ def test_contains(
             tags=[Tag(tag) for tag in tags],
         )
     ) is result
-
-
-##############################################################################
-def test_editing_a_raindrop_property_that_does_not_exist() -> None:
-    """Attempting to edit a property that doesn't exist should be an error."""
-    with raises(TypeError):
-        Raindrop().edit(not_a_property=42)
-
-
-##############################################################################
-def test_an_edited_raindrop_should_be_a_different_instance() -> None:
-    """When you edit a Raindrop it should result in a new instance."""
-    raindrop = Raindrop()
-    assert raindrop.edit(title="Changed") is not raindrop
 
 
 ##############################################################################


### PR DESCRIPTION
This PR fixes a bug where, after Raindrop has exited and been run up again, and the data hasn't been refreshed from raindrop.io yet, a raindrop that is moved to trash appears to report that it's still a member of its old collection (when the collection should show as trash).

This come down to the fact that internally I'm serialising the data locally using the raw JSON that comes down from the server, but if I update the properties of a raindrop I don't refresh that raw data. The reason for this is that add and edit operations against the API always give back a fresh copy of the data and I use that. Delete, on the other hand, just returns success or failure but no raindrop data (which makes some sense: delete a raindrop elsewhere and it goes to trash and so has a new collection, a raindrop _in_ trash just gets nuked).

Longer-term I should have a think about improving the way I locally write the data, or perhaps pull back a raindrop after deleting it, if it wasn't in trash to start with, but for now this PR patches the raw data to ensure the local state matches the remote state.

Fixes #47.