### PR TITLE
Fix crash when given a child collection sans parent

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,8 @@
   ([#53](https://github.com/davep/braindrop/pull/53))
 - Notes are now rendered as a Markdown document.
   ([#60](https://github.com/davep/braindrop/pull/60))
+- Fixed a crash caused by Raindrop sometimes including collections without
+  parents in the list of child collections.
 
 ## v0.3.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@
   ([#60](https://github.com/davep/braindrop/pull/60))
 - Fixed a crash caused by Raindrop sometimes including collections without
   parents in the list of child collections.
+  ([#61](https://github.com/davep/braindrop/pull/61))
 
 ## v0.3.0
 

--- a/src/braindrop/raindrop/collection.py
+++ b/src/braindrop/raindrop/collection.py
@@ -74,7 +74,13 @@ class Collection:
             sort=data.get("sort", 0),
             title=data.get("title", ""),
             view=data.get("view", ""),
-            parent=data.get("parent", {}).get("$id"),
+            # The rather awkward defaulting here comes from the fact that
+            # the Raindrop API seems to include a child collection that has
+            # been moved to the top-level in the list of child collections;
+            # but has its `parent` be `null` -- not even an empty object.
+            # This feels like a bug in Raindrop, or at least in its API.
+            # This works around that.
+            parent=(data.get("parent") or {}).get("$id"),
         )
 
 


### PR DESCRIPTION
It seems that if, in Raindrop, you create a child collection, then move it to the top level, you end up with a child collection that has no parent rather than a top-level collection.

This handles that situation.