### PR TITLE
Fix the collection count for groups

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,9 @@
 - Added handling of the Raindrop.IO API rate limit when downloading all the
   data. ([#22](https://github.com/davep/braindrop/issues/22),
   [#72](https://github.com/davep/braindrop/issues/72))
+- Fixed a problem where groups were showing the total collection count
+  rather than the count of collections in that group.
+  ([#77](https://github.com/davep/braindrop/issues/77))
 
 ## v0.4.0
 

--- a/src/braindrop/app/widgets/navigation.py
+++ b/src/braindrop/app/widgets/navigation.py
@@ -297,7 +297,7 @@ class Navigation(OptionListEx):
                 return
             # Populate the groups.
             for group in self.data.user.groups:
-                self.add_option(Title(f"{group.title} ({len(self.data.collections)})"))
+                self.add_option(Title(f"{group.title} ({len(group.collections)})"))
                 for collection in group.collections:
                     self._add_children_for(
                         self._add_collection(self.data.collection(collection))


### PR DESCRIPTION
Each group header was showing the total count of collections rather than the count of collections within that group.

Fixes #77.