### PR TITLE
Fix the count of collections within a group

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Braindrop ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Fixed the count of collections within a group when there is a hierarchy of
+  collections in that group.
+  ([#86](https://github.com/davep/braindrop/issues/86))
+
 ## v0.5.0
 
 **Released: 2025-01-11**

--- a/src/braindrop/app/widgets/navigation.py
+++ b/src/braindrop/app/widgets/navigation.py
@@ -297,7 +297,9 @@ class Navigation(OptionListEx):
                 return
             # Populate the groups.
             for group in self.data.user.groups:
-                self.add_option(Title(f"{group.title} ({len(group.collections)})"))
+                self.add_option(
+                    Title(f"{group.title} ({len(self.data.collections_within(group))})")
+                )
                 for collection in group.collections:
                     self._add_children_for(
                         self._add_collection(self.data.collection(collection))


### PR DESCRIPTION
Whereas #78 fixed the over-counting of collections within a group, this fixes the under-counting of them when the collections within a group is a hierarchy (the API only returns the top-level collections for the group).

Fixes #86.