### PR TITLE
Adds link and domain to locations of free-text search

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,9 @@
   collections in that group.
   ([#86](https://github.com/davep/braindrop/issues/86))
 - Free text search now also looks in the link of a raindrop.
+  ([#96](https://github.com/davep/braindrop/pull/96))
 - Free text search now also looks in the domain of a raindrop.
+  ([#96](https://github.com/davep/braindrop/pull/96))
 
 ## v0.5.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@
 - Fixed the count of collections within a group when there is a hierarchy of
   collections in that group.
   ([#86](https://github.com/davep/braindrop/issues/86))
+- Free text search now also looks in the link of a raindrop.
+- Free text search now also looks in the domain of a raindrop.
 
 ## v0.5.0
 

--- a/src/braindrop/raindrop/raindrop.py
+++ b/src/braindrop/raindrop/raindrop.py
@@ -209,6 +209,8 @@ class Raindrop:
             search_text in self.title.casefold()
             or search_text in self.excerpt.casefold()
             or search_text in self.note.casefold()
+            or search_text in self.link.casefold()
+            or search_text in self.domain.casefold()
             or self.is_tagged(Tag(search_text))
         )
 

--- a/tests/unit/test_raindrop.py
+++ b/tests/unit/test_raindrop.py
@@ -102,27 +102,56 @@ def test_is_tagged(
 
 ##############################################################################
 @mark.parametrize(
-    "needle, title, excerpt, note, link, tags, result",
+    "needle, title, excerpt, note, link, domain, tags, result",
     (
-        ("title", "title", "excerpt", "note", "link", ("tag",), True),
-        ("Title", "title", "excerpt", "note", "link", ("tag",), True),
-        ("excerpt", "title", "excerpt", "note", "link", ("tag",), True),
-        ("Excerpt", "title", "excerpt", "note", "link", ("tag",), True),
-        ("note", "title", "excerpt", "note", "link", ("tag",), True),
-        ("Note", "title", "excerpt", "note", "link", ("tag",), True),
-        ("tag", "title", "excerpt", "note", "link", ("tag",), True),
-        ("Tag", "title", "excerpt", "note", "link", ("tag",), True),
-        ("link", "title", "excerpt", "note", "link", ("tag",), True),
-        ("Link", "title", "excerpt", "note", "link", ("tag",), True),
-        ("here", "ishere", "andhere", "alsohere", "herealso", ("heretoo",), True),
+        ("title", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        ("Title", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        ("excerpt", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        ("Excerpt", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        ("note", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        ("Note", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        ("tag", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        ("Tag", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        ("link", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        ("Link", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        ("domain", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        ("Domain", "title", "excerpt", "note", "link", "domain", ("tag",), True),
+        (
+            "here",
+            "ishere",
+            "andhere",
+            "alsohere",
+            "herealso",
+            "ohsohere",
+            ("heretoo",),
+            True,
+        ),
         # Originally I was just smushing all the text-like parts of a
         # Raindrop together, which could result in false positives (actually
         # actual positives but they'd seem false to the average user). This
         # tests that I don't make that mistake again.
-        ("excerpt title", "title", "excerpt", "note", "link", ("tag",), False),
-        ("title note", "title", "excerpt", "note", "link", ("tag",), False),
-        ("note tag", "title", "excerpt", "note", "link", ("tag",), False),
-        ("tag1 tag2", "title", "excerpt", "note", "link", ("tag1", "tag2"), False),
+        (
+            "excerpt title",
+            "title",
+            "excerpt",
+            "note",
+            "link",
+            "domain",
+            ("tag",),
+            False,
+        ),
+        ("title note", "title", "excerpt", "note", "link", "domain", ("tag",), False),
+        ("note tag", "title", "excerpt", "note", "link", "domain", ("tag",), False),
+        (
+            "tag1 tag2",
+            "title",
+            "excerpt",
+            "note",
+            "link",
+            "domain",
+            ("tag1", "tag2"),
+            False,
+        ),
     ),
 )
 def test_contains(
@@ -131,6 +160,7 @@ def test_contains(
     excerpt: str,
     note: str,
     link: str,
+    domain: str,
     tags: tuple[str, ...],
     result: bool,
 ) -> None:
@@ -142,6 +172,7 @@ def test_contains(
             excerpt=excerpt,
             note=note,
             link=link,
+            domain=domain,
             tags=[Tag(tag) for tag in tags],
         )
     ) is result

--- a/tests/unit/test_raindrop.py
+++ b/tests/unit/test_raindrop.py
@@ -102,25 +102,27 @@ def test_is_tagged(
 
 ##############################################################################
 @mark.parametrize(
-    "needle, title, excerpt, note, tags, result",
+    "needle, title, excerpt, note, link, tags, result",
     (
-        ("title", "title", "excerpt", "note", ("tag",), True),
-        ("Title", "title", "excerpt", "note", ("tag",), True),
-        ("excerpt", "title", "excerpt", "note", ("tag",), True),
-        ("Excerpt", "title", "excerpt", "note", ("tag",), True),
-        ("note", "title", "excerpt", "note", ("tag",), True),
-        ("Note", "title", "excerpt", "note", ("tag",), True),
-        ("tag", "title", "excerpt", "note", ("tag",), True),
-        ("Tag", "title", "excerpt", "note", ("tag",), True),
-        ("here", "ishere", "andhere", "alsohere", ("heretoo",), True),
+        ("title", "title", "excerpt", "note", "link", ("tag",), True),
+        ("Title", "title", "excerpt", "note", "link", ("tag",), True),
+        ("excerpt", "title", "excerpt", "note", "link", ("tag",), True),
+        ("Excerpt", "title", "excerpt", "note", "link", ("tag",), True),
+        ("note", "title", "excerpt", "note", "link", ("tag",), True),
+        ("Note", "title", "excerpt", "note", "link", ("tag",), True),
+        ("tag", "title", "excerpt", "note", "link", ("tag",), True),
+        ("Tag", "title", "excerpt", "note", "link", ("tag",), True),
+        ("link", "title", "excerpt", "note", "link", ("tag",), True),
+        ("Link", "title", "excerpt", "note", "link", ("tag",), True),
+        ("here", "ishere", "andhere", "alsohere", "herealso", ("heretoo",), True),
         # Originally I was just smushing all the text-like parts of a
         # Raindrop together, which could result in false positives (actually
         # actual positives but they'd seem false to the average user). This
         # tests that I don't make that mistake again.
-        ("excerpt title", "title", "excerpt", "note", ("tag",), False),
-        ("title note", "title", "excerpt", "note", ("tag",), False),
-        ("note tag", "title", "excerpt", "note", ("tag",), False),
-        ("tag1 tag2", "title", "excerpt", "note", ("tag1", "tag2"), False),
+        ("excerpt title", "title", "excerpt", "note", "link", ("tag",), False),
+        ("title note", "title", "excerpt", "note", "link", ("tag",), False),
+        ("note tag", "title", "excerpt", "note", "link", ("tag",), False),
+        ("tag1 tag2", "title", "excerpt", "note", "link", ("tag1", "tag2"), False),
     ),
 )
 def test_contains(
@@ -128,6 +130,7 @@ def test_contains(
     title: str,
     excerpt: str,
     note: str,
+    link: str,
     tags: tuple[str, ...],
     result: bool,
 ) -> None:
@@ -138,6 +141,7 @@ def test_contains(
             title=title,
             excerpt=excerpt,
             note=note,
+            link=link,
             tags=[Tag(tag) for tag in tags],
         )
     ) is result


### PR DESCRIPTION
I guess, technically, there's no need to search the domain field if we're searching the link field; but then again I'm not 100% sure that Raindrop won't ever give data where these don't differ, and the cost of doing that search is near nothing.

Closes #93.

See also #89. While this comes nowhere near the suggestion (which I want to tackle in the not-too-distant future), it helps with better searching right now.