### PR TITLE
Rework the tag counts

### DIFF
--- a/src/braindrop/app/data/__init__.py
+++ b/src/braindrop/app/data/__init__.py
@@ -10,7 +10,7 @@ from .config import (
 )
 from .exit_state import ExitState
 from .local import LocalData, local_data_file
-from .raindrops import Raindrops
+from .raindrops import Raindrops, TagCount
 from .token import token_file
 
 ##############################################################################
@@ -22,6 +22,7 @@ __all__ = [
     "local_data_file",
     "LocalData",
     "Raindrops",
+    "TagCount",
     "save_configuration",
     "token_file",
     "update_configuration",

--- a/src/braindrop/app/data/raindrops.py
+++ b/src/braindrop/app/data/raindrops.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 ##############################################################################
 # Python imports.
-from typing import Counter, Iterable, Iterator
+from dataclasses import dataclass
+from typing import Callable, Counter, Iterable, Iterator
 
 ##############################################################################
 # Typing extension imports.
@@ -19,8 +20,44 @@ from ...raindrop import (
     Raindrop,
     SpecialCollection,
     Tag,
-    TagData,
 )
+
+
+##############################################################################
+@dataclass(frozen=True)
+class TagCount:
+    """Holds count details of a tag."""
+
+    tag: Tag
+    """The name of the tag."""
+    count: int
+    """The number of Raindrops using this tag."""
+
+    @staticmethod
+    def the_tag() -> Callable[[TagCount], Tag]:
+        """Returns a function for getting the tag from a `TagCount` instance.
+
+        Returns:
+            A function to get the tag of a `TagCount` instance.
+        """
+
+        def _getter(data: TagCount) -> Tag:
+            return data.tag
+
+        return _getter
+
+    @staticmethod
+    def the_count() -> Callable[[TagCount], int]:
+        """Returns a function for getting the count from a `TagCount` instance.
+
+        Returns:
+            A function to get the count of a `TagCount` instance.
+        """
+
+        def _getter(data: TagCount) -> int:
+            return data.count
+
+        return _getter
 
 
 ##############################################################################
@@ -213,12 +250,12 @@ class Raindrops:
         return f"{'; '.join((self._title, *filters))} ({len(self)})"
 
     @property
-    def tags(self) -> list[TagData]:
+    def tags(self) -> list[TagCount]:
         """The list of unique tags found amongst the Raindrops."""
         tags: list[Tag] = []
         for raindrop in self:
             tags.extend(set(raindrop.tags))
-        return [TagData(name, count) for name, count in Counter(tags).items()]
+        return [TagCount(name, count) for name, count in Counter(tags).items()]
 
     def __and__(self, new_filter: Filter) -> Raindrops:
         """Get the raindrops that match a given filter.

--- a/src/braindrop/app/providers/tags.py
+++ b/src/braindrop/app/providers/tags.py
@@ -2,8 +2,7 @@
 
 ##############################################################################
 # Local imports.
-from ...raindrop import TagData
-from ..data import Raindrops
+from ..data import Raindrops, TagCount
 from ..messages import ShowTagged
 from .commands_provider import CommandHit, CommandHits, CommandsProvider
 
@@ -35,7 +34,7 @@ class TagCommands(CommandsProvider):
         command_prefix = (
             "Also tagged" if self.active_collection.is_filtered else "Tagged"
         )
-        for tag in sorted(self.active_collection.tags, key=TagData.the_tag()):
+        for tag in sorted(self.active_collection.tags, key=TagCount.the_tag()):
             yield CommandHit(
                 f"{command_prefix} {tag.tag}",
                 f"{help_prefix} to Raindrops tagged with {tag.tag} (narrows down to {tag.count})",

--- a/src/braindrop/app/suggestions/tags.py
+++ b/src/braindrop/app/suggestions/tags.py
@@ -11,14 +11,15 @@ from textual.suggester import Suggester
 
 ##############################################################################
 # Local imports.
-from ...raindrop import Raindrop, Tag, TagData
+from ...raindrop import Raindrop, Tag
+from ..data import TagCount
 
 
 ##############################################################################
 class SuggestTags(Suggester):
     """A Textual `Input` suggester that suggests tags."""
 
-    def __init__(self, tags: Iterable[Tag | TagData], use_cache: bool = True) -> None:
+    def __init__(self, tags: Iterable[Tag | TagCount], use_cache: bool = True) -> None:
         """Initialise the suggester.
 
         Args:
@@ -29,7 +30,7 @@ class SuggestTags(Suggester):
         # being case-sensitive; so here we say we *are* going to be case
         # sensitive and then in get_suggestion we'll handle it ourselves.
         super().__init__(use_cache=use_cache, case_sensitive=True)
-        self._tags = [tag.tag if isinstance(tag, TagData) else tag for tag in tags]
+        self._tags = [tag.tag if isinstance(tag, TagCount) else tag for tag in tags]
         """The tags to take suggestions from."""
 
     _SUGGESTABLE: Final[Pattern[str]] = re.compile(r".*[^,\s]$")

--- a/src/braindrop/app/widgets/navigation.py
+++ b/src/braindrop/app/widgets/navigation.py
@@ -23,9 +23,9 @@ from textual.widgets.option_list import Option
 
 ##############################################################################
 # Local imports.
-from ...raindrop import API, Collection, SpecialCollection, Tag, TagData
+from ...raindrop import API, Collection, SpecialCollection, Tag
 from ..commands import ShowAll, ShowUnsorted, ShowUntagged
-from ..data import LocalData, Raindrops
+from ..data import LocalData, Raindrops, TagCount
 from ..messages import ShowCollection, ShowTagged
 from .extended_option_list import OptionListEx
 
@@ -102,7 +102,7 @@ class CollectionView(Option):
 class TagView(Option):
     """Option for showing a tag."""
 
-    def __init__(self, tag: TagData) -> None:
+    def __init__(self, tag: TagCount) -> None:
         """Initialise the object.
 
         Args:
@@ -126,7 +126,7 @@ class TagView(Option):
         return prompt
 
     @property
-    def tag_data(self) -> TagData:
+    def tag_data(self) -> TagCount:
         """The tag data."""
         return self._tag
 
@@ -306,7 +306,7 @@ class Navigation(OptionListEx):
                     )
 
     @staticmethod
-    def _by_name(tags: list[TagData]) -> list[TagData]:
+    def _by_name(tags: list[TagCount]) -> list[TagCount]:
         """Return a given list of tags sorted by tag name.
 
         Args:
@@ -315,10 +315,10 @@ class Navigation(OptionListEx):
         Returns:
             The sorted list of tags.
         """
-        return sorted(tags, key=TagData.the_tag())
+        return sorted(tags, key=TagCount.the_tag())
 
     @staticmethod
-    def _by_count(tags: list[TagData]) -> list[TagData]:
+    def _by_count(tags: list[TagCount]) -> list[TagCount]:
         """Return a given list of tags sorted by count.
 
         Args:
@@ -327,7 +327,7 @@ class Navigation(OptionListEx):
         Returns:
             The sorted list of tags.
         """
-        return sorted(tags, key=TagData.the_count(), reverse=True)
+        return sorted(tags, key=TagCount.the_count(), reverse=True)
 
     def _show_tags_for(self, collection: Raindrops) -> None:
         """Show tags relating a given collection.

--- a/src/braindrop/raindrop/__init__.py
+++ b/src/braindrop/raindrop/__init__.py
@@ -6,7 +6,7 @@ from .api import API
 from .collection import Collection, SpecialCollection
 from .raindrop import Raindrop, RaindropType
 from .suggestions import Suggestions
-from .tag import Tag, TagData
+from .tag import Tag
 from .time_tools import get_time
 from .user import Group, User
 
@@ -22,7 +22,6 @@ __all__ = [
     "SpecialCollection",
     "Suggestions",
     "Tag",
-    "TagData",
     "User",
 ]
 

--- a/src/braindrop/raindrop/api.py
+++ b/src/braindrop/raindrop/api.py
@@ -28,7 +28,6 @@ from httpx import AsyncClient, HTTPStatusError, RequestError, Response
 from .collection import Collection, SpecialCollection
 from .raindrop import Raindrop
 from .suggestions import Suggestions
-from .tag import TagData
 from .user import User
 
 
@@ -345,20 +344,6 @@ class API:
                 break
         count_update(len(raindrops))
         return raindrops
-
-    async def tags(self, collection: int | None = None) -> list[TagData]:
-        """Get a list of tags.
-
-        Args:
-            collection: The optional collection to get the tags for.
-
-        Returns:
-            A list of tags.
-        """
-        _, tags = await self._items_of(
-            self._get, "/tags" if collection is None else f"/tags/{collection}"
-        )
-        return [TagData.from_json(tag) for tag in tags or []]
 
     async def add_raindrop(self, raindrop: Raindrop) -> Raindrop | None:
         """Add a raindrop.

--- a/src/braindrop/raindrop/tag.py
+++ b/src/braindrop/raindrop/tag.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 
 ##############################################################################
 # Python imports.
-from dataclasses import dataclass
 from functools import total_ordering
-from typing import Any, Callable
 
 
 ##############################################################################
@@ -88,58 +86,6 @@ class Tag:
     def __len__(self) -> int:
         """The length of the tag."""
         return len(self._tag)
-
-
-##############################################################################
-@dataclass(frozen=True)
-class TagData:
-    """Holds details of a tag."""
-
-    tag: Tag
-    """The name of the tag."""
-    count: int
-    """The number of Raindrops using this tag."""
-
-    @staticmethod
-    def from_json(data: dict[str, Any]) -> TagData:
-        """Create a tag from JSON-sourced data.
-
-        Args:
-            data: The data to create the object from.
-
-        Returns:
-            A fresh `TagData` instance.
-        """
-        return TagData(
-            tag=Tag(data["_id"]),
-            count=data.get("count", 0),
-        )
-
-    @staticmethod
-    def the_tag() -> Callable[[TagData], Tag]:
-        """Returns a function for getting the tag from a `TagData` instance.
-
-        Returns:
-            A function to get the tag of a `TagData` instance.
-        """
-
-        def _getter(data: TagData) -> Tag:
-            return data.tag
-
-        return _getter
-
-    @staticmethod
-    def the_count() -> Callable[[TagData], int]:
-        """Returns a function for getting the count from a `TagData` instance.
-
-        Returns:
-            A function to get the count of a `TagData` instance.
-        """
-
-        def _getter(data: TagData) -> int:
-            return data.count
-
-        return _getter
 
 
 ### tag.py ends here

--- a/tests/unit/test_raindrops.py
+++ b/tests/unit/test_raindrops.py
@@ -2,8 +2,8 @@
 
 ##############################################################################
 # Local imports.
-from braindrop.app.data import Raindrops
-from braindrop.raindrop import Raindrop, Tag, TagData
+from braindrop.app.data import Raindrops, TagCount
+from braindrop.raindrop import Raindrop, Tag
 
 
 ##############################################################################
@@ -43,7 +43,7 @@ def test_found_tags() -> None:
     repeat = 2
     assert Raindrops(
         raindrops=[Raindrop(tags=[Tag(tag)]) for tag in expecting * repeat]
-    ).tags == list(TagData(Tag(tag), repeat) for tag in expecting)
+    ).tags == list(TagCount(Tag(tag), repeat) for tag in expecting)
 
 
 ##############################################################################


### PR DESCRIPTION
This PR removes the `tags` method from the API class; it was never used and all tag counting is done locally anyway.

Also renames `TagData` to `TagCount`.