### PR TITLE
Handle unknown collections

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Braindrop ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Made the code that loads a group's collections more defensive, hopefully
+  to fix a crash one person was reporting.
+  ([#106](https://github.com/davep/braindrop/pull/106))
+
 ## v0.6.0
 
 **Released: 2025-01-14**

--- a/src/braindrop/app/data/local.py
+++ b/src/braindrop/app/data/local.py
@@ -179,6 +179,9 @@ class LocalData:
         # can work it out).
         return collection.count or len(self.in_collection(collection))
 
+    class UnknonwCollection(Exception):
+        """Exception raised if we encounter a collection ID we don't know about."""
+
     def collection(self, identity: int) -> Collection:
         """Get a collection from its ID.
 
@@ -187,12 +190,18 @@ class LocalData:
 
         Returns:
             The collection with that identity.
+
+        Raises:
+            UnknownCollection: When a collection isn't known.
         """
-        return (
-            SpecialCollection(identity)()
-            if identity in SpecialCollection
-            else self._collections[identity]
-        )
+        try:
+            return (
+                SpecialCollection(identity)()
+                if identity in SpecialCollection
+                else self._collections[identity]
+            )
+        except KeyError:
+            raise self.UnknonwCollection(f"Unknown collection identity: {identity}")
 
     @property
     def collections(self) -> list[Collection]:

--- a/src/braindrop/app/data/local.py
+++ b/src/braindrop/app/data/local.py
@@ -201,7 +201,9 @@ class LocalData:
                 else self._collections[identity]
             )
         except KeyError:
-            raise self.UnknonwCollection(f"Unknown collection identity: {identity}")
+            raise self.UnknonwCollection(
+                f"Unknown collection identity: {identity}"
+            ) from None
 
     @property
     def collections(self) -> list[Collection]:

--- a/src/braindrop/app/data/local.py
+++ b/src/braindrop/app/data/local.py
@@ -224,16 +224,23 @@ class LocalData:
         Notes:
             The returned list is a flat list of *all* the collections within
             the group; no specific order is guaranteed.
+
+            The Raindrop API has been known to apparently include IDs for
+            collections, within a group, where the collection no longer
+            exists. With this in mind any unknown collections are pruned.
         """
 
         def _collections(collection_ids: Iterable[int]) -> Iterator[Collection]:
             for collection in collection_ids:
-                yield self.collection(collection)
-                yield from _collections(
-                    candidate.identity
-                    for candidate in self.collections
-                    if candidate.parent == collection
-                )
+                try:
+                    yield self.collection(collection)
+                    yield from _collections(
+                        candidate.identity
+                        for candidate in self.collections
+                        if candidate.parent == collection
+                    )
+                except self.UnknonwCollection:
+                    pass
 
         return list(_collections(group.collections))
 

--- a/src/braindrop/app/widgets/navigation.py
+++ b/src/braindrop/app/widgets/navigation.py
@@ -338,9 +338,18 @@ class Navigation(OptionListEx):
                     Title(f"{group.title} ({len(self.data.collections_within(group))})")
                 )
                 for collection in group.collections:
-                    self._add_children_for(
-                        self._add_collection(self.data.collection(collection))
-                    )
+                    try:
+                        self._add_children_for(
+                            self._add_collection(self.data.collection(collection))
+                        )
+                    except self.data.UnknonwCollection:
+                        # It seems that the Raindrop API can sometimes say
+                        # there's a collection ID in a group where the
+                        # collection ID isn't in the actual collections the
+                        # API gives us. So here we just ignore it.
+                        #
+                        # https://github.com/davep/braindrop/issues/104
+                        pass
 
     @staticmethod
     def _by_name(tags: list[TagCount]) -> list[TagCount]:


### PR DESCRIPTION
Based off what is reported in #104 it would appear that the Raindrop API can end up reporting that a group has collections where the collection doesn't actually exist. It's unclear how this situation can arise, and I can't personally make it happen.

However, whatever the cause, a collection within a group where the collection doesn't exist any more should be a collection to ignore, to pretend it doesn't exist. This PR seeks to implement that.

Fixes #104.
