### PR TITLE
Have Markdown in the help fall back on its container background

### DIFF
--- a/src/braindrop/app/screens/help.py
+++ b/src/braindrop/app/screens/help.py
@@ -74,7 +74,7 @@ class HelpScreen(ModalScreen[None]):
 
         Markdown, MarkdownTable {
             padding: 0 1 0 1;
-            background: $panel;
+            background: transparent;
         }
 
         MarkdownH1 {


### PR DESCRIPTION
Rather than set the background by hand, go with what the parent has. Now I think about it it's weird that Textual doesn't do this out of the box.