### PR TITLE
Remove an unused export from screens

### DIFF
--- a/src/braindrop/app/screens/__init__.py
+++ b/src/braindrop/app/screens/__init__.py
@@ -2,12 +2,11 @@
 
 ##############################################################################
 # Local imports.
-from .downloading import Downloading
 from .main import Main
 from .token_input import TokenInput
 
 ##############################################################################
 # Exports.
-__all__ = ["Downloading", "Main", "TokenInput"]
+__all__ = ["Main", "TokenInput"]
 
 ### __init__.py ends here


### PR DESCRIPTION
Nothing else is using it outwith of screens, so there's little point in making a point of exporting it.