### PR TITLE
Style locally-used tag suggestions different from others

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Braindrop ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Tag suggestions displayed below the tag input field in the raindrop
+  editing dialog now style locally-known tags differently from suggestions
+  that haven't ever been used by the user.
+
 ## v0.6.1
 
 **Released: 2025-01-15**


### PR DESCRIPTION
When displaying suggested tags for a given URL, style those that the user has already used in a more positive light vs suggestions that are novel to the user. This way it's a wee bit easier to stick with your own tag convention.