### PR TITLE
Reinstate the commands shown in the footer

### DIFF
--- a/src/braindrop/app/commands/collection.py
+++ b/src/braindrop/app/commands/collection.py
@@ -10,7 +10,6 @@ class SearchCollections(Command):
     """Search for a collection by name and show its contents"""
 
     BINDING_KEY = "C"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -18,7 +17,6 @@ class ShowAll(Command):
     """Show all Raindrops"""
 
     BINDING_KEY = "a"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -26,7 +24,6 @@ class ShowUnsorted(Command):
     "Show all unsorted Raindrops"
 
     BINDING_KEY = "u"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -34,7 +31,6 @@ class ShowUntagged(Command):
     """Show all Raindrops that are lacking tags"""
 
     BINDING_KEY = "U"
-    SHOW_IN_FOOTER = False
 
 
 ### collection.py ends here

--- a/src/braindrop/app/commands/filtering.py
+++ b/src/braindrop/app/commands/filtering.py
@@ -18,7 +18,6 @@ class ClearFilters(Command):
     """Clear all tags and other filters"""
 
     BINDING_KEY = "f"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -26,7 +25,6 @@ class Search(Command):
     """Search for text anywhere in the raindrops"""
 
     BINDING_KEY = "/"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -35,7 +33,6 @@ class SearchTags(Command):
     """Search for a tag and then filter with it"""
 
     BINDING_KEY = "t, #"
-    SHOW_IN_FOOTER = False
 
     active_collection: Raindrops = Raindrops()
     """The active collection to search within."""

--- a/src/braindrop/app/commands/main.py
+++ b/src/braindrop/app/commands/main.py
@@ -10,7 +10,6 @@ class ChangeTheme(Command):
     """Change the application's theme"""
 
     BINDING_KEY = "f9"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -18,6 +17,7 @@ class CompactMode(Command):
     "Toggle the compact mode for the Raindrop list"
 
     BINDING_KEY = "f5"
+    SHOW_IN_FOOTER = True
 
 
 ##############################################################################
@@ -25,6 +25,7 @@ class Details(Command):
     """Toggle the view of the current Raindrop's details"""
 
     BINDING_KEY = "f3"
+    SHOW_IN_FOOTER = True
 
 
 ##############################################################################
@@ -32,7 +33,6 @@ class Escape(Command):
     "Back up through the panes, right to left, or exit the app if the navigation pane has focus"
 
     BINDING_KEY = "escape"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -40,7 +40,6 @@ class Logout(Command):
     """Forget your API token and remove the local raindrop cache"""
 
     BINDING_KEY = "f12"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -48,7 +47,6 @@ class Redownload(Command):
     "Download a fresh copy of all data from raindrop.io"
 
     BINDING_KEY = "ctrl+r"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -56,6 +54,7 @@ class TagOrder(Command):
     "Toggle the tags sort order between by-name and by-count"
 
     BINDING_KEY = "f4"
+    SHOW_IN_FOOTER = True
 
 
 ##############################################################################
@@ -65,6 +64,7 @@ class VisitRaindrop(Command):
     COMMAND = "Visit raindrop.io"
     BINDING_KEY = "f2"
     FOOTER_TEXT = "raindrop.io"
+    SHOW_IN_FOOTER = True
 
 
 ### main.py ends here

--- a/src/braindrop/app/commands/raindrop.py
+++ b/src/braindrop/app/commands/raindrop.py
@@ -10,7 +10,6 @@ class AddRaindrop(Command):
     """Add a new raindrop"""
 
     BINDING_KEY = "n"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -18,7 +17,6 @@ class CheckTheWaybackMachine(Command):
     """Check if the currently-highlighted raindrop is archived in the Wayback Machine"""
 
     BINDING_KEY = "w"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -26,7 +24,6 @@ class CopyLinkToClipboard(Command):
     """Copy the currently-highlighted link to the clipboard"""
 
     BINDING_KEY = "c"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -34,7 +31,6 @@ class DeleteRaindrop(Command):
     """Delete the currently-highlighted raindrop"""
 
     BINDING_KEY = "d, delete"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -42,7 +38,6 @@ class EditRaindrop(Command):
     """Edit the currently-highlighted raindrop"""
 
     BINDING_KEY = "e"
-    SHOW_IN_FOOTER = False
 
 
 ##############################################################################
@@ -50,7 +45,6 @@ class VisitLink(Command):
     """Visit currently-highlighted link"""
 
     BINDING_KEY = "v"
-    SHOW_IN_FOOTER = False
 
 
 ### raindrop.py ends here


### PR DESCRIPTION
After swapping over to basing on textual-enhanced I forgot to account for the switch in the default for SHOW_IN_FOOTER.