### PR TITLE
:books: Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ like something that makes sense for Braindrop I'll turn it into an issue
 from there.
 
 Be sure to [have a look over the TODO
-isues](https://github.com/davep/braindrop/issues?q=is%3Aissue+is%3Aopen+label%3ATODO)
+issues](https://github.com/davep/braindrop/issues?q=is%3Aissue+is%3Aopen+label%3ATODO)
 before leaving a request, it might be I'm already planning on implementing
 whatever it is you're asking for.
 

--- a/src/braindrop/app/data/local.py
+++ b/src/braindrop/app/data/local.py
@@ -179,7 +179,7 @@ class LocalData:
         # can work it out).
         return collection.count or len(self.in_collection(collection))
 
-    class UnknonwCollection(Exception):
+    class UnknownCollection(Exception):
         """Exception raised if we encounter a collection ID we don't know about."""
 
     def collection(self, identity: int) -> Collection:
@@ -201,7 +201,7 @@ class LocalData:
                 else self._collections[identity]
             )
         except KeyError:
-            raise self.UnknonwCollection(
+            raise self.UnknownCollection(
                 f"Unknown collection identity: {identity}"
             ) from None
 
@@ -241,7 +241,7 @@ class LocalData:
                         for candidate in self.collections
                         if candidate.parent == collection
                     )
-                except self.UnknonwCollection:
+                except self.UnknownCollection:
                     pass
 
         return list(_collections(group.collections))

--- a/src/braindrop/app/widgets/navigation.py
+++ b/src/braindrop/app/widgets/navigation.py
@@ -342,7 +342,7 @@ class Navigation(EnhancedOptionList):
                         self._add_children_for(
                             self._add_collection(self.data.collection(collection))
                         )
-                    except self.data.UnknonwCollection:
+                    except self.data.UnknownCollection:
                         # It seems that the Raindrop API can sometimes say
                         # there's a collection ID in a group where the
                         # collection ID isn't in the actual collections the

--- a/src/braindrop/app/widgets/raindrops_view.py
+++ b/src/braindrop/app/widgets/raindrops_view.py
@@ -126,7 +126,7 @@ class RaindropsView(EnhancedOptionList):
     ## The Raindrop collection view
 
     This panel shows the currently-selected collection of Raindrops,
-    filtered by any tag ans search text you may have applied.
+    filtered by any tag and search text you may have applied.
 
     Each Raindrop may have one or more icons showing to the right, these
     include:

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -62,7 +62,7 @@ def test_sort_tags() -> None:
 
 ##############################################################################
 @mark.parametrize("string", ("", "1"))
-def test_tag_langth(string: str) -> None:
+def test_tag_length(string: str) -> None:
     """We should be able to get the len of a tag."""
     assert len(Tag(string)) == len(string)
 


### PR DESCRIPTION
Found via `codespell -L wee` and `typos --hidden --format brief`