### PR TITLE
Ensure the correct Python is used in the matrix of checks

### DIFF
--- a/.github/workflows/style-lint-and-test.yaml
+++ b/.github/workflows/style-lint-and-test.yaml
@@ -32,7 +32,9 @@ jobs:
           version: "latest"
 
       - name: Install Dependencies
-        run: make setup
+        run: |
+          echo ${{ matrix.python-version }} > .python-version
+          make setup
 
       - name: Check for typos
         run: make spellcheck


### PR DESCRIPTION
Correct the SNAFU where I wasn't actually running tests with the actual Python version specified in the matrix.