### PR TITLE
Fix Enter not visiting a raindrop's link any more

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Braindrop ChangeLog
 
+## v0.8.1
+
+**Released: 2025-05-06**
+
+- Fixed <kbd>Enter</kbd> not visiting the raindrop link any more.
+
 ## v0.8.0
 
 **Released: 2025-05-01**

--- a/src/braindrop/app/screens/main.py
+++ b/src/braindrop/app/screens/main.py
@@ -493,6 +493,7 @@ class Main(EnhancedScreen[None]):
             return None
         return raindrop.link
 
+    @on(VisitLink)
     def action_visit_link_command(self) -> None:
         """Visit the currently-highlighted link."""
         if (link := self._current_link("visit")) is None:


### PR DESCRIPTION
In cleaning up the messages-vs-actions thing when it comes to commands, I'd got carried away. This fixes that.