### PR TITLE
Fix a clash with the new `compact` property in Textual

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Braindrop ChangeLog
 
+## v0.8.2
+
+**Released: 2025-05-09**
+
+- Fixed clash with Textual's newly-introduced `compact` reactive.
+
 ## v0.8.1
 
 **Released: 2025-05-06**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 **Released: 2025-05-09**
 
 - Fixed clash with Textual's newly-introduced `compact` reactive.
+  ([#156](https://github.com/davep/braindrop/pull/156))
 
 ## v0.8.1
 

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -45,7 +45,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via braindrop
-humanize==4.12.2
+humanize==4.12.3
     # via braindrop
 identify==2.6.10
     # via pre-commit
@@ -82,7 +82,7 @@ nodeenv==1.9.1
     # via pre-commit
 packaging==25.0
     # via pytest
-platformdirs==4.3.7
+platformdirs==4.3.8
     # via textual
     # via virtualenv
 pluggy==1.5.0
@@ -107,7 +107,7 @@ rich==14.0.0
     # via textual-serve
 sniffio==1.3.1
     # via anyio
-textual==3.1.1
+textual==3.2.0
     # via braindrop
     # via textual-dev
     # via textual-enhanced
@@ -125,7 +125,7 @@ typing-extensions==4.13.2
     # via textual-dev
 uc-micro-py==1.0.3
     # via linkify-it-py
-virtualenv==20.30.0
+virtualenv==20.31.2
     # via pre-commit
 xdg-base-dirs==6.0.2
     # via braindrop

--- a/requirements.lock
+++ b/requirements.lock
@@ -21,7 +21,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via braindrop
-humanize==4.12.2
+humanize==4.12.3
     # via braindrop
 idna==3.10
     # via anyio
@@ -36,7 +36,7 @@ mdit-py-plugins==0.4.2
     # via markdown-it-py
 mdurl==0.1.2
     # via markdown-it-py
-platformdirs==4.3.7
+platformdirs==4.3.8
     # via textual
 pygments==2.19.1
     # via rich
@@ -48,7 +48,7 @@ rich==14.0.0
     # via textual
 sniffio==1.3.1
     # via anyio
-textual==3.1.1
+textual==3.2.0
     # via braindrop
     # via textual-enhanced
 textual-enhanced==0.13.0

--- a/src/braindrop/app/screens/main.py
+++ b/src/braindrop/app/screens/main.py
@@ -284,7 +284,7 @@ class Main(EnhancedScreen[None]):
         config = load_configuration()
         self.set_class(not config.details_visible, "details-hidden")
         self.query_one(Navigation).tags_by_count = config.show_tags_by_count
-        self.query_one(RaindropsView).compact = config.compact_mode
+        self.query_one(RaindropsView).compact_view = config.compact_mode
         self.load_data()
 
     def watch_active_collection(self) -> None:
@@ -424,11 +424,11 @@ class Main(EnhancedScreen[None]):
 
     def action_compact_mode_command(self) -> None:
         """Toggle the compact mode for the list of raindrops."""
-        self.query_one(RaindropsView).compact = not self.query_one(
+        self.query_one(RaindropsView).compact_view = not self.query_one(
             RaindropsView
-        ).compact
+        ).compact_view
         with update_configuration() as config:
-            config.compact_mode = self.query_one(RaindropsView).compact
+            config.compact_mode = self.query_one(RaindropsView).compact_view
 
     @work
     async def action_search_command(self) -> None:

--- a/src/braindrop/app/widgets/raindrops_view.py
+++ b/src/braindrop/app/widgets/raindrops_view.py
@@ -143,7 +143,7 @@ class RaindropsView(EnhancedOptionList):
     raindrops: var[Raindrops] = var(Raindrops)
     """The list of raindrops being shown."""
 
-    compact: var[bool] = var(False)
+    compact_view: var[bool] = var(False)
     """Toggle to say if we should use a compact view or not."""
 
     class Empty(Message):
@@ -154,7 +154,7 @@ class RaindropsView(EnhancedOptionList):
         with self.preserved_highlight:
             self.clear_options().add_options(
                 [
-                    RaindropView(raindrop, self.data, self.compact)
+                    RaindropView(raindrop, self.data, self.compact_view)
                     for raindrop in self.raindrops
                 ]
             )
@@ -169,7 +169,7 @@ class RaindropsView(EnhancedOptionList):
         """React to the raindrops being changed."""
         self._add_raindrops()
 
-    def watch_compact(self) -> None:
+    def watch_compact_view(self) -> None:
         """React to the compact setting being toggled."""
         self._add_raindrops()
 


### PR DESCRIPTION
Yay for stable application frameworks and sensible semantic versioning. /s