### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/style-lint-and-test.yaml
+++ b/.github/workflows/style-lint-and-test.yaml
@@ -1,5 +1,8 @@
 name: Code quality tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/davep/braindrop/security/code-scanning/1](https://github.com/davep/braindrop/security/code-scanning/1)

To fix the problem, explicitly declare restricted `GITHUB_TOKEN` permissions in the workflow. The least-privilege configuration for this job is to allow read access to repository contents so `actions/checkout` can function, while denying write access to everything else. This is done by adding a `permissions` block that sets `contents: read`.

The single best fix without changing existing functionality is to add a workflow-level `permissions` block near the top of `.github/workflows/style-lint-and-test.yaml`, after the `name:` and before `on:`. This will apply to all jobs (currently just `style-lint-and-test`) without altering any steps. No additional imports, actions, or changes to steps are needed; we simply specify:

```yaml
permissions:
  contents: read
```

This documents the workflow’s needs and ensures it remains restricted even if organization or repository defaults change later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
